### PR TITLE
BoardConfig: Suggest 1080x2520 framebuffer-console cmdline

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -29,6 +29,9 @@ PRODUCT_PLATFORM := nagara
 BOARD_BOOTCONFIG += androidboot.hardware=pdx224
 BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx224
 
+# FB console
+#BOARD_KERNEL_CMDLINE += earlycon=simplefb,0xb8000000,1080,2520
+
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
 BOARD_BOOTIMAGE_PARTITION_SIZE := 0x06000000


### PR DESCRIPTION
The commented-out kernel cmdline suggestion in the nagara platform repo is only applicable to 1IV (pdx223) with its larger screen: suggest a commented-out simplefb config for 5IV with the appropriate resolution here in the pdx224 repository (platform suggestion will be removed and moved to pdx223, too).
